### PR TITLE
Feat/improved file completion

### DIFF
--- a/ArgumentParsing.cpp
+++ b/ArgumentParsing.cpp
@@ -211,8 +211,6 @@ std::string compgen(int argc, char const* const* argv) {
 	tokenize(argc, argv, commandCB, paramCB);
 
 	std::set<std::string> hints;
-	bool can_accept_file {false};
-	bool can_accept_directory {false};
 
 	if (lastArgName.empty()) {
 		auto const& subC = argProviders.back()->getSubCommands();
@@ -230,20 +228,9 @@ std::string compgen(int argc, char const* const* argv) {
 		if (target == params.end()) {
 			continue;
 		}
-		auto useParam = [&] {
-			auto [cur_canAcceptNextArg, cur_hints] = (*target)->getValueHints(lastArguments);
-			canAcceptNextArg &= cur_canAcceptNextArg;
-			hints.insert(cur_hints.begin(), cur_hints.end());
-		};
-		if ((*target)->get_type() == typeid(File)) {
-			useParam();
-			can_accept_file = not canAcceptNextArg;
-		} else if ((*target)->get_type() == typeid(Directory)) {
-			useParam();
-			can_accept_directory = not canAcceptNextArg;
-		} else {
-			useParam();
-		}
+		auto [cur_canAcceptNextArg, cur_hints] = (*target)->getValueHints(lastArguments);
+		canAcceptNextArg &= cur_canAcceptNextArg;
+		hints.insert(cur_hints.begin(), cur_hints.end());
 	}
 
 	if (canAcceptNextArg) {
@@ -256,12 +243,6 @@ std::string compgen(int argc, char const* const* argv) {
 		}
 	}
 	std::string compgen_str;
-	if (can_accept_directory) {
-		compgen_str += " -d \n";
-	}
-	if (can_accept_file) {
-		compgen_str += " -f \n";
-	}
 	if (not hints.empty()) {
 		compgen_str += std::accumulate(next(begin(hints)), end(hints), *begin(hints), [](std::string const& l , std::string const& r){
 			return l + "\n" + r;

--- a/File.h
+++ b/File.h
@@ -1,17 +1,8 @@
 #pragma once
 
-#include <filesystem>
 #include "Parameter.h"
 
 namespace sargp {
-
-/*struct File final : std::filesystem::path {
-	using std::filesystem::path::path;
-};
-
-struct Directory final : std::filesystem::path {
-	using std::filesystem::path::path;
-};*/
 
 enum class File { Single, Multi };
 inline auto completeFile(std::string extension = "", File file = File::Single) {
@@ -19,16 +10,7 @@ inline auto completeFile(std::string extension = "", File file = File::Single) {
 		if (file == File::Single and c.size() > 1 or c.empty()) {
 			return {true, {}};
 		}
-		if (c.empty() or c.back().empty()) {
-			if (extension.empty()) {
-				return {false, {" -f "}};
-			}
-			return {false, {" -f *" + extension, " -d "}};
-		}
-		if (extension.empty()) {
-			return {false, {" -f " + c.back()}};
-		}
-		return {false, {" -f " + c.back() + "*" + extension, " -d " + c.back()}};
+		return {false, {" -f " + extension}};
 	};
 }
 inline auto completeDirectory(File file = File::Single) {
@@ -37,10 +19,7 @@ inline auto completeDirectory(File file = File::Single) {
 			return {true, {}};
 		}
 
-		if (c.empty()) {
-			return {false, {" -d "}};
-		}
-		return {false, {" -d " + c.back()}};
+		return {false, {" -d "}};
 	};
 }
 

--- a/File.h
+++ b/File.h
@@ -5,12 +5,43 @@
 
 namespace sargp {
 
-struct File final : std::filesystem::path {
+/*struct File final : std::filesystem::path {
 	using std::filesystem::path::path;
 };
 
 struct Directory final : std::filesystem::path {
 	using std::filesystem::path::path;
-};
+};*/
+
+enum class File { Single, Multi };
+inline auto completeFile(std::string extension = "", File file = File::Single) {
+	return [file, extension](std::vector<std::string> const& c) -> std::pair<bool, std::set<std::string>> {
+		if (file == File::Single and c.size() > 1 or c.empty()) {
+			return {true, {}};
+		}
+		if (c.empty() or c.back().empty()) {
+			if (extension.empty()) {
+				return {false, {" -f "}};
+			}
+			return {false, {" -f *" + extension, " -d "}};
+		}
+		if (extension.empty()) {
+			return {false, {" -f " + c.back()}};
+		}
+		return {false, {" -f " + c.back() + "*" + extension, " -d " + c.back()}};
+	};
+}
+inline auto completeDirectory(File file = File::Single) {
+	return [file](std::vector<std::string> const& c) -> std::pair<bool, std::set<std::string>> {
+		if (file == File::Single and c.size() > 1 or c.empty()) {
+			return {true, {}};
+		}
+
+		if (c.empty()) {
+			return {false, {" -d "}};
+		}
+		return {false, {" -d " + c.back()}};
+	};
+}
 
 }

--- a/Parameter.h
+++ b/Parameter.h
@@ -236,9 +236,12 @@ public:
 		if (SuperClass::_hintFunc) {
 			return SuperClass::_hintFunc(args);
 		}
+		if (args.size() != 1) {
+			return {true, {}};
+		}
 		std::set<std::string> names;
 		for (auto const& n2v : _name2ValMap) { names.emplace(n2v.first); };
-		return std::make_pair<bool, std::set<std::string>>(args.size() == 1, std::move(names));
+		return std::make_pair<bool, std::set<std::string>>(false , std::move(names));
 	}
 
 	std::string describe() const override {

--- a/bash_completion
+++ b/bash_completion
@@ -10,25 +10,25 @@ else
     function sargparse_GetOpts ()
     {
         mapfile -t HINTS <<< $(${COMP_LINE[0]} "${COMP_WORDS[@]:1}" --bash_completion)
-        if [[ "${HINTS}" =~ " -d " ]] || [[ "${HINTS}" =~ " -f " ]]; then
-#            local IFS=$'\r'
-            COMPREPLY=()
-            for ((i=0; i < ${#HINTS[@]}; i++)); do
-	            COMPREPLY+=( $(compgen ${HINTS[i]} -- ${2}) )
-            done
-
-            for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
-                [ -d "${COMPREPLY[$i]}" ] && COMPREPLY[$i]=${COMPREPLY[$i]}/
-            done
-
-            if [ ${#COMPREPLY[@]} = 1 ]; then
-                [ -f "$COMPREPLY" ] && COMPREPLY=$(printf %q%s "$COMPREPLY" " ")
-            fi
+        if [ "${HINTS}" == " -d " ]; then
+            compopt -o filenames
+            local IFS=$'\n'
+            COMPREPLY=( $(compgen -d -- ${2}) )
+        elif [ "${HINTS}" == " -f " ]; then
+            compopt -o filenames
+            local IFS=$'\n'
+            COMPREPLY=( $(compgen -f -- ${2}) )
+        elif [[ "${HINTS}" =~ " -f " ]]; then
+            compopt -o filenames
+            EXT="$(echo "${HINTS}" | cut -d ' ' -f 3)"
+            local IFS=$'\n'
+            COMPREPLY=( $(compgen -d -- ${2}) )
+            COMPREPLY+=( $(compgen -f -X '!*'${EXT} -- ${2}) )
         else
             HINTS=$(printf "%q:" "${HINTS[@]}")
             local IFS=":"
             mapfile -t COMPREPLY <<< $(compgen -W '${HINTS}' -- "${COMP_WORDS[COMP_CWORD]}")
         fi
     }
-    complete -o nospace -F sargparse_GetOpts $1
+    complete -F sargparse_GetOpts $1
 fi

--- a/bash_completion
+++ b/bash_completion
@@ -9,9 +9,13 @@ if [ ${#} != "1" ] || ! [ -f $1 ]; then
 else
     function sargparse_GetOpts ()
     {
-        mapfile -t HINTS <<< $(${COMP_LINE[0]} ${COMP_WORDS[@]:1} --bash_completion)
-        if [ "${HINTS}" == " -d " ] || [ "${HINTS}" == " -f " ]; then
-            COMPREPLY=( $(eval compgen ${HINTS[@]} -- ${2}) )
+        mapfile -t HINTS <<< $(${COMP_LINE[0]} "${COMP_WORDS[@]:1}" --bash_completion)
+        if [[ "${HINTS}" =~ " -d " ]] || [[ "${HINTS}" =~ " -f " ]]; then
+#            local IFS=$'\r'
+            COMPREPLY=()
+            for ((i=0; i < ${#HINTS[@]}; i++)); do
+	            COMPREPLY+=( $(compgen ${HINTS[i]} -- ${2}) )
+            done
 
             for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
                 [ -d "${COMPREPLY[$i]}" ] && COMPREPLY[$i]=${COMPREPLY[$i]}/

--- a/zsh_completion
+++ b/zsh_completion
@@ -13,7 +13,7 @@ else
 		globalCommands=$(echo ${globalParams} | grep "^[^-][^-]")
 		globalOptions=$(echo ${globalParams} | grep "^--")
 
-		localParams=$(${PROG} ${words[@]:1} --bash_completion)
+		localParams=$(${PROG} ${(@q)words[@]:1} --bash_completion)
 		localCommands=$(echo ${localParams} | grep "^[^-][^-]")
 		localOptions=$(echo ${localParams} | grep "^--")
 		localSpecialOptions=$(echo ${localParams} | grep "^ -")
@@ -30,6 +30,9 @@ else
 			_files -/
 		elif [ "${localSpecialOptions}" = " -f " ]; then
 			_files
+		elif [[ "${localSpecialOptions}" =~ " -f " ]]; then
+			EXT="$(echo "${localSpecialOptions}" | cut -d ' ' -f 3)"
+			_files -g "*${EXT}"
 		else
 			compadd -J "G4" -X "%USuggestions%u" -- ${localCommands[@]}
 			compadd -J "G3" -X "%ULocal Options%u" -- ${localOptions[@]}


### PR DESCRIPTION
Improvement of file completion on bash and zsh.
- Now files with spaces should work on completion
- completion of files is closer to the common completion behavior of programs like `ls` in bash
- Removed extra types `sargp::File` and `sargp::Directory` by replacing them with `completeFile(...)` and `completeDirctory(...)` function.

Now following things should work (notice the trailing spaces):
- `./exampleSargparse <tab><tab>` show list of all commands and parameters
- `./exampleSargparse --my_<tab><tab>` this should auto complete to `./exampleSargparse --my_enum `
- `./exampleSargparse --my_enum B<tab><tab>` complete to `./exampleSargparse --my_enum Bar `
- `./exampleSargparse --mySection.file <tab><tab>` complete by showing file and directory list
- `./exampleSargparse --mySection.file LICENSE <tab><tab>` complete by showing all commands and parameters
- `./exampleSargparse --mySection.multi_files LICENSE <tab><tab>` complete by showing file and directory list
- `./exampleSargparse --mySection.multi_files LICENSE --<tab><tab>` complete by showing all parameters
- `./exampleSargparse --mySection.cpp_file <tab><tab>` complete by showing all *.cpp files and directories
